### PR TITLE
Make it fast 🚀

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -15,4 +15,6 @@ jobs:
           node-version: 14
       - run: yarn
       - run: yarn build
+        env:
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
       - run: yarn test

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,21 @@
 import Airtable from 'airtable';
 
-function mapRecordToPlant(record) {
+type Record = {
+  name: {
+    pl: string[];
+    en: string[];
+    lat: string;
+  };
+  slug: string;
+  imageID: number;
+  danger: number;
+  source: string[];
+  ID: string;
+  symptoms: string;
+  note: string;
+};
+
+function mapRecordToPlant(record): Record {
   return {
     name: {
       pl: record['name.pl']?.split(',').map((value) => value.trim()),
@@ -17,7 +32,9 @@ function mapRecordToPlant(record) {
   };
 }
 
-async function getPlantsByType(type) {
+type Plants = Record[];
+
+async function getPlantsByType(type: string): Promise<Plants> {
   return new Promise((resolve, reject) => {
     const base = Airtable.base('app0awhBu3GphBQkq');
     const res = [];
@@ -50,7 +67,9 @@ async function getPlantsByType(type) {
   });
 }
 
-export async function getAllPlants() {
+type AllPlants = { toxic: Plants; safe: Plants };
+
+export async function getAllPlants(): Promise<AllPlants> {
   try {
     const [Toxic, Safe] = await Promise.all([
       getPlantsByType('Safe'),

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -55,11 +55,11 @@ export async function getStaticPaths() {
   return {
     paths: [
       { params: { slug: [] } },
-      ...[...plants.safe, ...plants.toxic].map((plant) => ({
+      ...[...(plants.safe as any), ...(plants.toxic as any)].map((plant) => ({
         params: { slug: [plant.slug] },
       })),
     ],
-    fallback: false,
+    fallback: true,
   };
 }
 
@@ -68,5 +68,6 @@ export async function getStaticProps() {
 
   return {
     props: { plants },
+    revalidate: 1,
   };
 }

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -49,7 +49,21 @@ export default function Home({ plants }) {
   );
 }
 
-export async function getServerSideProps() {
+export async function getStaticPaths() {
+  const plants = await getAllPlants();
+  console.log({ plants });
+  return {
+    paths: [
+      { params: { slug: [] } },
+      ...[...plants.safe, ...plants.toxic].map((plant) => ({
+        params: { slug: [plant.slug] },
+      })),
+    ],
+    fallback: false,
+  };
+}
+
+export async function getStaticProps() {
   const plants = await getAllPlants();
 
   return {

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -51,11 +51,10 @@ export default function Home({ plants }) {
 
 export async function getStaticPaths() {
   const plants = await getAllPlants();
-  console.log({ plants });
   return {
     paths: [
       { params: { slug: [] } },
-      ...[...(plants.safe as any), ...(plants.toxic as any)].map((plant) => ({
+      ...[...plants.safe, ...plants.toxic].map((plant) => ({
         params: { slug: [plant.slug] },
       })),
     ],

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -59,7 +59,7 @@ export async function getStaticPaths() {
         params: { slug: [plant.slug] },
       })),
     ],
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,9 +2579,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001165:
-  version "1.0.30001165"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz#32955490d2f60290bb186bb754f2981917fa744f"
-  integrity sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==
+  version "1.0.30001183"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz"
+  integrity sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Switch to statically generated page. I implemented stale while revalidate approach which is possible in nextjs and made it even faster by cheat next.js a bit ;).

Page is regenerated under the hood 1 per second on vercel and there is no need to run CI/CD after change to airtable (adding and deleting also work!) - background regeneration ensures traffic is served, always from static storage, and the newly built page is pushed only after it's done generating.

![Screenshot 2021-02-01 at 23 28 36](https://user-images.githubusercontent.com/8572321/106527720-01c7e580-64e8-11eb-90d5-b74fe08168d1.png)


preview: https://cats-test-inife7x6w.vercel.app/

PS. we need env variables both in github (for static build) and vercel (for incremental build) :)